### PR TITLE
Posts index route

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
+    "axios": "^0.17.1",
     "babel-preset-stage-1": "^6.1.18",
     "lodash": "^3.10.1",
     "react": "^0.14.3",
@@ -33,6 +34,7 @@
     "react-redux": "4.3.0",
     "react-router": "^2.0.1",
     "react-router-dom": "^4.0.0",
-    "redux": "^3.0.4"
+    "redux": "^3.0.4",
+    "redux-promise": "^0.5.3"
   }
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+export const FETCH_POSTS = "fetch_posts";
+
+const ROOT_URL = "http://reduxblog.herokuapp.com/api";
+const API_KEY = "?key=tpayne910";
+
+export function fetchPosts() {
+  const request = axios.get(`${ROOT_URL}/posts${API_KEY}`);
+
+  return {
+    type: FETCH_POSTS,
+    payload:  request
+  };
+}

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,9 +1,0 @@
-import React, { Component } from 'react';
-
-export default class App extends Component {
-  render() {
-    return (
-      <div>React simple starter</div>
-    );
-  }
-}

--- a/src/components/posts_index.js
+++ b/src/components/posts_index.js
@@ -1,0 +1,11 @@
+import React, { Component } from 'react';
+
+class PostsIndex extends Component {
+  render() {
+    return (
+      <div>Hello from Posts Index!</div>
+    );
+  }
+}
+
+export default PostsIndex;

--- a/src/components/posts_index.js
+++ b/src/components/posts_index.js
@@ -1,11 +1,38 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux'
+import _ from "lodash";
+
+import { fetchPosts } from '../actions';
 
 class PostsIndex extends Component {
+  componentDidMount() {
+    this.props.fetchPosts();
+  }
+  
+  renderPosts() {
+    return _.map(this.props.posts, post => {
+      return (
+        <li key={post.id} className="list-group-item">
+          {post.title}
+        </li>
+      );
+    });
+  }
+
   render() {
     return (
-      <div>Hello from Posts Index!</div>
+      <div>
+        <h3>Posts</h3>
+        <ul className="list-group">
+          {this.renderPosts()}
+        </ul>
+      </div>
     );
   }
 }
 
-export default PostsIndex;
+function mapStateToProps(state) {
+  return { posts: state.posts };
+}
+
+export default connect(mapStateToProps, { fetchPosts })(PostsIndex);

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import { BrowserRouter, Route } from "react-router-dom";
 
-import App from './components/app';
 import reducers from './reducers';
+import PostsIndex from './components/posts_index';
 
 const createStoreWithMiddleware = applyMiddleware()(createStore);
 
@@ -13,6 +13,7 @@ ReactDOM.render(
   <Provider store={createStoreWithMiddleware(reducers)}>
     <BrowserRouter>
       <div>
+          <Route path="/" component={PostsIndex} />
       </div>
     </BrowserRouter>
   </Provider>

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,12 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import { BrowserRouter, Route } from "react-router-dom";
+import promise from "redux-promise";
 
 import reducers from './reducers';
 import PostsIndex from './components/posts_index';
 
-const createStoreWithMiddleware = applyMiddleware()(createStore);
+const createStoreWithMiddleware = applyMiddleware(promise)(createStore);
 
 ReactDOM.render(
   <Provider store={createStoreWithMiddleware(reducers)}>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,8 @@
 import { combineReducers } from 'redux';
+import PostsReducer from './reducer_posts'; 
 
 const rootReducer = combineReducers({
-  state: (state = {}) => state
+  posts: PostsReducer
 });
 
 export default rootReducer;

--- a/src/reducers/reducer_posts.js
+++ b/src/reducers/reducer_posts.js
@@ -1,0 +1,12 @@
+import _ from "lodash";
+
+import { FETCH_POSTS } from "../actions";
+
+export default function(state = {}, action) {
+  switch(action.type) {
+    case FETCH_POSTS:
+      return _.mapKeys(action.payload.data, "id");
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
Add the functionality to retrieve a list of all posts from the API and display them in the Posts Index Component. The posts are a part of the state. The posts state is managed by a Redux Reducer, `PostsReducer`. The posts are fetched from an action dispatcher that is called when the `PostsIndex` component is rendered. This component is rendered when the user navigates to the React Route `/`.